### PR TITLE
fix 0-length seek inside a non-resident attribute list

### DIFF
--- a/src/attribute_value/attribute_list_non_resident.rs
+++ b/src/attribute_value/attribute_list_non_resident.rs
@@ -219,7 +219,7 @@ impl<'n, 'f> NtfsReadSeek for NtfsAttributeListNonResidentAttributeValue<'n, 'f>
             _ => unreachable!(),
         };
 
-        while bytes_left_to_seek > 0 {
+        loop {
             // Seek inside the current Data Run if there is one.
             if self
                 .stream_state


### PR DESCRIPTION
Subnode VCN can sometimes be equal to 0, which leads to a panic
when it is used to seek inside a
NtfsAttributeListNonResidentAttributeValue.

This is caused by the seek implementation expecting to always have
bytes to seek, even if there is no current data run for the reader.

Relaxing this test into a loop fixes the issue. The `seek_data_run`
call will just return Ok(false), and we will iterate into a next data
run properly.