### PR TITLE
handle large sectors_per_cluster (closes #12)

### DIFF
--- a/src/boot_sector.rs
+++ b/src/boot_sector.rs
@@ -46,7 +46,7 @@ impl BiosParameterBlock {
         /// Source: https://en.wikipedia.org/wiki/NTFS
         const MAXIMUM_CLUSTER_SIZE: u32 = 2097152;
 
-        let cluster_size = self.sectors_per_cluster as u32 * self.sector_size as u32;
+        let cluster_size = self.sectors_per_cluster() * self.sector_size as u32;
         if cluster_size > MAXIMUM_CLUSTER_SIZE || !cluster_size.is_power_of_two() {
             return Err(NtfsError::UnsupportedClusterSize {
                 expected: MAXIMUM_CLUSTER_SIZE,
@@ -55,6 +55,14 @@ impl BiosParameterBlock {
         }
 
         Ok(cluster_size)
+    }
+
+    fn sectors_per_cluster(&self) -> u32 {
+        if self.sectors_per_cluster > 128 {
+            1 << (256 - self.sectors_per_cluster as u32)
+        } else {
+            self.sectors_per_cluster as u32
+        }
     }
 
     pub(crate) fn file_record_size(&self) -> Result<u32> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -164,9 +164,11 @@ pub enum NtfsError {
     /// The type of the NTFS Attribute at byte position {position:#010x} is {actual:#010x}, which is not supported
     UnsupportedAttributeType { position: u64, actual: u32 },
     /// The cluster size is {actual} bytes, but the maximum supported one is {expected}
-    UnsupportedClusterSize { expected: u32, actual: u32 },
+    UnsupportedClusterSize { expected: u64, actual: u64 },
     /// The namespace of the NTFS file name starting at byte position {position:#010x} is {actual}, which is not supported
     UnsupportedFileNamespace { position: u64, actual: u8 },
+    /// The cluster size is 2^{actual} bytes, but the maximum supported is 2^{expected}
+    UnsupportedSectorsPerClusterExponent { expected: u32, actual: u32 },
     /// The sector size is {actual} bytes, but the only supported one is {expected}
     UnsupportedSectorSize { expected: u16, actual: u16 },
     /// The Update Sequence Array (USA) of the record at byte position {position:#010x} has entries for {array_count} sectors of {sector_size} bytes, but the record is only {record_size} bytes long


### PR DESCRIPTION
This follows [Wikipedia's description](https://en.wikipedia.org/wiki/NTFS#Partition_Boot_Sector_(PBS)) "If the value is greater than 0x80, the amount of sectors is 2 to the power of the absolute value of considering this field to be negative."

Annoyingly sectors_per_cluster can't just be an i8 with different behavior depending on the sign because that breaks for 128 (so a cluster size of 64k).