### PR TITLE
fix: do not panic on binrw backtrace error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,8 @@ pub enum NtfsError {
         expected: NtfsAttributeType,
         actual: NtfsAttributeType,
     },
+    /// Error while deserializing data: {0:?}
+    BinrwError(binrw::error::Error),
     /// The given buffer should have at least {expected} bytes, but it only has {actual} bytes
     BufferTooSmall { expected: usize, actual: usize },
     /// The NTFS Attribute at byte position {position:#x} has a length of {expected} bytes, but only {actual} bytes are left in the record
@@ -232,8 +234,9 @@ impl From<binrw::error::Error> for NtfsError {
         if let binrw::error::Error::Io(io_error) = error {
             Self::Io(io_error)
         } else {
-            // We don't use any binrw attributes that result in other errors.
-            unreachable!("Got a binrw error of unexpected type: {:?}", error);
+            // Generic binrw error. This is generally a binrw::backtrace::Error that
+            // contains details about the parsing issue.
+            Self::BinrwError(error)
         }
     }
 }


### PR DESCRIPTION
The ntfs crate could panic on some data because of a false "unreachable" instruction in error.rs: the binrw error is not guaranteed to only be an IO error, it can also be for example a backtrace error.

I have reached this panic several times in different contexts.

This PR removes this unreachable which is too dangerous: any update of binrw could make this unreachable wrong, it is better to be conservative here.